### PR TITLE
Fix category icon

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -1,7 +1,7 @@
 
 //% block=Scroller
 //% color="#ff85a7"
-//% icon="\uf047"
+//% icon="\uf0b2"
 namespace scroller {
     export enum CameraScrollMode {
         //% block="only horizontally"


### PR DESCRIPTION
I guess the character code changed! Restoring the old icon.

Fixes https://github.com/microsoft/pxt-arcade/issues/4091